### PR TITLE
Switch to NpmClientHandler

### DIFF
--- a/LSP-typescript.sublime-commands
+++ b/LSP-typescript.sublime-commands
@@ -4,7 +4,7 @@
         "command": "edit_settings",
         "args": {
             "base_file": "${packages}/LSP-typescript/LSP-typescript.sublime-settings",
-            "default": "// Settings in here override those in \"LSP-typescript/LSP-typescript.sublime-settings\",\n\n{\n\t$0\n}\n"
+            "default": "// Settings in here override those in \"LSP-typescript/LSP-typescript.sublime-settings\"\n\n{\n\t$0\n}\n"
         }
     },
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -20,7 +20,7 @@
                     "command": "edit_settings",
                     "args": {
                       "base_file": "${packages}/LSP-typescript/LSP-typescript.sublime-settings",
-                      "default": "// Settings in here override those in \"LSP-typescript/LSP-typescript.sublime-settings\",\n\n{\n\t$0\n}\n",
+                      "default": "// Settings in here override those in \"LSP-typescript/LSP-typescript.sublime-settings\"\n\n{\n\t$0\n}\n",
                     }
                   }
                 ]

--- a/plugin.py
+++ b/plugin.py
@@ -12,7 +12,7 @@ def plugin_unloaded():
 
 class LspTypescriptPlugin(NpmClientHandler):
     package_name = __package__
-    server_directory = 'LSP-typescript.sublime-settings'
+    server_directory = 'typescript-language-server'
     server_binary_path = os.path.join(
         server_directory, 'node_modules', 'typescript-language-server', 'lib', 'cli.js'
     )

--- a/plugin.py
+++ b/plugin.py
@@ -1,4 +1,8 @@
 import os
+import sublime
+from LSP.plugin.core.protocol import Point
+from LSP.plugin.core.url import uri_to_filename
+from LSP.plugin.core.views import point_to_offset
 from lsp_utils import NpmClientHandler
 
 
@@ -16,3 +20,23 @@ class LspTypescriptPlugin(NpmClientHandler):
     server_binary_path = os.path.join(
         server_directory, 'node_modules', 'typescript-language-server', 'lib', 'cli.js'
     )
+
+    def on_ready(self, api) -> None:
+        api.on_request('_typescript.rename', self._on_typescript_rename)
+
+    def _on_typescript_rename(self, textDocumentPositionParams, respond):
+        view = sublime.active_window().open_file(
+            uri_to_filename(textDocumentPositionParams['textDocument']['uri'])
+        )
+
+        if view:
+            lsp_point = Point.from_lsp(textDocumentPositionParams['position'])
+            point = point_to_offset(lsp_point, view)
+
+            sel = view.sel()
+            sel.clear()
+            sel.add_all([point])
+            view.run_command('lsp_symbol_rename')
+
+        # Server doesn't require any specific response.
+        respond(None)

--- a/plugin.py
+++ b/plugin.py
@@ -1,100 +1,18 @@
-import shutil
 import os
-import sublime
-
-from LSP.plugin.core.handlers import LanguageHandler
-from LSP.plugin.core.settings import ClientConfig, read_client_config
-from LSP.plugin.core.rpc import Client
-from LSP.plugin.core.views import point_to_offset
-from LSP.plugin.core.protocol import Point
-from LSP.plugin.core.typing import Dict
-from LSP.plugin.core.url import uri_to_filename
-from lsp_utils import ServerNpmResource
-
-
-PACKAGE_NAME = 'LSP-typescript'
-SETTINGS_FILENAME = 'LSP-typescript.sublime-settings'
-SERVER_DIRECTORY = 'typescript-language-server'
-SERVER_BINARY_PATH = os.path.join(SERVER_DIRECTORY, 'node_modules', 'typescript-language-server', 'lib', 'cli.js')
-
-server = ServerNpmResource(PACKAGE_NAME, SERVER_DIRECTORY, SERVER_BINARY_PATH)
+from lsp_utils import NpmClientHandler
 
 
 def plugin_loaded():
-    server.setup()
+    LspTypescriptPlugin.setup()
 
 
 def plugin_unloaded():
-    server.cleanup()
+    LspTypescriptPlugin.cleanup()
 
 
-def is_node_installed():
-    return shutil.which('node') is not None
-
-
-class LspTypeScriptPlugin(LanguageHandler):
-    @property
-    def name(self) -> str:
-        return PACKAGE_NAME.lower()
-
-    @property
-    def config(self) -> ClientConfig:
-        # Calling setup() also here as this might run before `plugin_loaded`.
-        # Will be a no-op if already ran.
-        # See https://github.com/sublimelsp/LSP/issues/899
-        server.setup()
-
-        configuration = self.migrate_and_read_configuration()
-
-        default_configuration = {
-            'enabled': True,
-            'command': ['node', server.binary_path, '--stdio'],
-        }
-
-        default_configuration.update(configuration)
-        return read_client_config(self.name, default_configuration)
-
-    def migrate_and_read_configuration(self) -> Dict:
-        settings = {}
-        loaded_settings = sublime.load_settings(SETTINGS_FILENAME)  # type: Dict
-
-        if loaded_settings:
-            if loaded_settings.has('client'):
-                client = loaded_settings.get('client')  # type: Dict
-                loaded_settings.erase('client')
-                # Migrate old keys
-                for key, value in client.items():
-                    loaded_settings.set(key, value)
-                sublime.save_settings(SETTINGS_FILENAME)
-
-            # Read configuration keys
-            for key in ['languages', 'initializationOptions', 'settings']:
-                settings[key] = loaded_settings.get(key)
-
-        return settings
-
-    def on_start(self, window) -> bool:
-        if not is_node_installed():
-            sublime.status_message('Please install Node.js for the TypeScript Language Server to work.')
-            return False
-        return server.ready
-
-    def on_initialized(self, client: Client) -> None:
-        client.on_request(
-            "_typescript.rename", lambda params, token: self._on_typescript_rename(params, token))
-
-    def _on_typescript_rename(self, textDocumentPositionParams, cancellationToken):
-        view = sublime.active_window().open_file(
-            uri_to_filename(textDocumentPositionParams['textDocument']['uri'])
-        )
-
-        if not view:
-            return
-
-        lsp_point = Point.from_lsp(textDocumentPositionParams['position'])
-        point = point_to_offset(lsp_point, view)
-
-        sel = view.sel()
-        sel.clear()
-        sel.add_all([point])
-        view.run_command('lsp_symbol_rename')
+class LspTypescriptPlugin(NpmClientHandler):
+    package_name = __package__
+    server_directory = 'LSP-typescript.sublime-settings'
+    server_binary_path = os.path.join(
+        server_directory, 'node_modules', 'typescript-language-server', 'lib', 'cli.js'
+    )


### PR DESCRIPTION
Removed "_typescript.rename" handler as I don't think it was used.
Renaming symbols is handled by built-in 'textDocument/rename'.