### PR TITLE
Fix languageId sent for react syntax and update scope

### DIFF
--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -17,7 +17,7 @@
 		},
 		{
 			"languageId": "typescriptreact",
-			"scopes": ["source.tsx", "source.ts.react"],
+			"scopes": ["source.tsx"],
 			"syntaxes": [
 				"Packages/TypeScript Syntax/TypeScriptReact.tmLanguage",
 			],

--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -1,6 +1,16 @@
 {
 	"languages": [
 		{
+			"languageId": "javascriptreact",
+			"scopes": [
+				"source.jsx",
+				"source.js.react",
+			],
+			"syntaxes": [
+				"Packages/User/JS Custom/Syntaxes/React.sublime-syntax",
+			],
+		},
+		{
 			"languageId": "javascript",
 			"scopes": [
 				"source.js",
@@ -8,15 +18,6 @@
 			"syntaxes": [
 				"Packages/JavaScript/JavaScript.sublime-syntax",
 				"Packages/Babel/JavaScript (Babel).sublime-syntax",
-			],
-		},
-		{
-			"languageId": "javascriptreact",
-			"scopes": [
-				"source.jsx",
-			],
-			"syntaxes": [
-				"Packages/User/JS Custom/Syntaxes/React.sublime-syntax",
 			],
 		},
 		{

--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -2,40 +2,31 @@
 	"languages": [
 		{
 			"languageId": "javascriptreact",
-			"scopes": [
-				"source.jsx",
-				"source.js.react",
-			],
+			"scopes": ["source.jsx", "source.js.react"],
 			"syntaxes": [
 				"Packages/User/JS Custom/Syntaxes/React.sublime-syntax",
 			],
 		},
 		{
 			"languageId": "javascript",
-			"scopes": [
-				"source.js",
-			],
+			"scopes": ["source.js"],
 			"syntaxes": [
 				"Packages/JavaScript/JavaScript.sublime-syntax",
 				"Packages/Babel/JavaScript (Babel).sublime-syntax",
 			],
 		},
 		{
-			"languageId": "typescript",
-			"scopes": [
-				"source.ts",
-			],
+			"languageId": "typescriptreact",
+			"scopes": ["source.tsx", "source.ts.react"],
 			"syntaxes": [
-				"Packages/TypeScript Syntax/TypeScript.tmLanguage",
+				"Packages/TypeScript Syntax/TypeScriptReact.tmLanguage",
 			],
 		},
 		{
-			"languageId": "typescriptreact",
-			"scopes": [
-				"source.tsx",
-			],
+			"languageId": "typescript",
+			"scopes": ["source.ts"],
 			"syntaxes": [
-				"Packages/TypeScript Syntax/TypeScriptReact.tmLanguage",
+				"Packages/TypeScript Syntax/TypeScript.tmLanguage",
 			],
 		},
 	],


### PR DESCRIPTION
"source.js.react" scope is used by JS Custom.
That whole language block needs to be first on the list as it's more
specific than "source.js". Otherwise we would send "languageId: javascript"
for react files.