### PR TITLE
Deno syntax support

### DIFF
--- a/deno_syntax.py
+++ b/deno_syntax.py
@@ -1,0 +1,26 @@
+import os
+import re
+import sublime
+import sublime_plugin
+
+
+RE_DENO_DEPS_CACHES_DIRPATH = re.compile(r".+\/deno\/deps\/.+", re.IGNORECASE)
+
+
+class DenoSyntaxListener(sublime_plugin.EventListener):
+    def on_load_async(self, view: sublime.View):
+        self.check_deno_syntax(view)
+
+    def check_deno_syntax(self, view: sublime.View):
+        if not (file_name := view.file_name()):
+            return
+        if not (view.scope_name(0).startswith("text.plain")):
+            return
+        if not RE_DENO_DEPS_CACHES_DIRPATH.match(file_name):
+            return
+        self.set_deno_syntax(view, "d." + os.path.basename(file_name[0:-60]) + ".ts")
+
+    def set_deno_syntax(self, view: sublime.View, name: str):
+        view.set_read_only(True)
+        view.set_name(name)
+        view.assign_syntax(sublime.find_syntax_for_file(name))


### PR DESCRIPTION
# 🤷‍♂️
> First ever python script for me

## Problem
`Go To Definition` for files in your `$DENO_DIR location: "~/Library/Caches/deno"` shows the 64 char hashed file `plain.text` syntax.

<details>
<summary>~/Library/Caches/deno/deps/https/deno.land/7485d77b79a7a2013747f1af5d7e54cdaa9bc2903b667e01c8827d4232408d9f</summary>
<img width="720" alt="Screen Shot 2020-08-26 at 1 42 04 PM" src="https://user-images.githubusercontent.com/1457327/91339241-3484e980-e7a4-11ea-9c1b-5475660094ec.png">
</details>

## Solution (_barely_)
When the file loads, match the `file_name` against the common `$DENO_DIR/**/*deno*/*deps*/**` pattern then assign `source.ts` syntax.

<details>
<summary>d.7485.ts</summary>
<img width="720" alt="Screen Shot 2020-08-26 at 1 50 52 PM" src="https://user-images.githubusercontent.com/1457327/91339729-e15f6680-e7a4-11ea-8746-7dd951937c6d.png">
</details>
