### PR TITLE
Define "command" in settings to make it easy to override

### DIFF
--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -1,4 +1,5 @@
 {
+	"command": ["node", "${cache_path}/LSP-typescript/typescript-language-server/node_modules/typescript-language-server/lib/cli.js", "--stdio"],
 	"languages": [
 		{
 			"languageId": "javascriptreact",

--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -1,5 +1,5 @@
 {
-	"command": ["node", "${cache_path}/LSP-typescript/typescript-language-server/node_modules/typescript-language-server/lib/cli.js", "--stdio"],
+	"command": ["node", "${server_path}", "--stdio"],
 	"languages": [
 		{
 			"languageId": "javascriptreact",


### PR DESCRIPTION
Even though I've made this PR, I think this is wrong as it has hardcoded forward slashes in the path and that is either not ideal or completely doesn't work on Windows.