### PR TITLE
Normalize line-endings on inserting imports to fix Windows issues

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -74,7 +74,7 @@ class LspTypescriptPlugin(NpmClientHandler):
                         (
                             (start['line'] - 1, start['offset'] - 1),
                             (end['line'] - 1, end['offset'] - 1),
-                            text_change['newText'],
+                            text_change['newText'].replace("\r", ""),
                             None,
                         )
                     )


### PR DESCRIPTION
This PR fixes an autoimport bug on Windows.

When we select a completion item `foobarbaz`. 

before this PR - windows will insert <0x0b> for \r chars:

```
const { foobarbaz } = require("./comp/b");<0x0b> 
<0x0b> 
foobarbaz
```

after tihs PR:
```
const { foobarbaz } = require("./comp/b");

foobarbaz
```