### PR TITLE
add some useful info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ To sort or remove unused imports you can trigger the `LSP-typescript: Organize I
         }
     },
 ```
+
+### Keybindings and Customization
+
+To replace default sublime `GoToDefinition` and add `GoToTypeDefinition` command add following keybinding
+```
+{ "keys": ["f11"], "command": "lsp_symbol_type_definition" },
+{ "keys": ["f12"], "command": "lsp_symbol_definition" },
+```
+For other available commands look at `Preferences -> Package Settings -> LSP -> Key Bindings`
+
+For available customizations (popups, ...) look at `Preferences -> Package Settings -> LSP -> Settings`


### PR DESCRIPTION
Added some useful info in readme. If you want, you can drop this pull request and write more appropriate text. 

Little story, why i added it. I installed this package few times, but found it very cluttered with various popups. Also there is no commands in `.sublime-commands` and useful settings in `.sublime-settings`. So i don't even realize that, when i click F12, the native GoToDefinition triggers, instead of LSP one. Because of that i returned to [Microsoft Ts Plugin](https://github.com/microsoft/TypeScript-Sublime-Plugin), which has few annoying bugs, but i have no alternative. And now i discovered settings under LSP package and it turns out that this plugin works more smoother, than Microsoft one and doesn't have his bugs :fire: