### PR TITLE
add typescript user preferences to the schema

### DIFF
--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -31,6 +31,15 @@
 			],
 		},
 	],
-	"initializationOptions": {},
+	"initializationOptions": {
+		"logVerbosity": "off",
+		"plugins": [],
+		"preferences": {
+			"allowRenameOfImportPath": true,
+			"includeCompletionsForImportStatements": true,
+			"includeCompletionsForModuleExports": true,
+			"includeCompletionsWithInsertText": true,
+		}
+	},
 	"settings": {},
 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -14,8 +14,12 @@
                                     "type": "object",
                                     "additionalProperties": false,
                                     "properties": {
-                                        "logVerbosity": {
+                                        "hostInfo": {
                                             "type": "string",
+                                            "markdownDescription": "Information about the host, for example `Emacs 24.4` or `Sublime Text version 3075`. This value is only relevant when using `yarn pnp` which might apply special logic for certain values."
+                                        },
+                                        "logVerbosity": {
+                                            "enum": ["off", "terse", "normal", "requesttime", "verbose"],
                                             "description": "Verbosity of the logging."
                                         },
                                         "plugins": {
@@ -41,6 +45,68 @@
                                                         }
                                                     }
                                                 ]
+                                            }
+                                        },
+                                        "preferences": {
+                                            "type": "object",
+                                            "properties": {
+                                                "disableSuggestions": {
+                                                    "type": "boolean",
+                                                },
+                                                "quotePreference": {
+                                                    "enum": ["auto", "double", "single"],
+                                                },
+                                                "includeCompletionsForModuleExports": {
+                                                    "type": "boolean",
+                                                    "markdownDescription": "If enabled, TypeScript will search through all external modules' exports and add them to the completions list. This affects lone identifier completions but not completions on the right hand side of `obj.`."
+                                                },
+                                                "includeCompletionsForImportStatements": {
+                                                    "type": "boolean",
+                                                    "markdownDescription": "Enables auto-import-style completions on partially-typed import statements. E.g., allows `import write|` to be completed to `import { writeFile } from \"fs\"`."
+                                                },
+                                                "includeCompletionsWithSnippetText": {
+                                                    "type": "boolean",
+                                                    "markdownDescription": "Allows completions to be formatted with snippet text, indicated by `CompletionItem[\"isSnippet\"]`."
+                                                },
+                                                "includeCompletionsWithInsertText": {
+                                                    "type": "boolean",
+                                                    "markdownDescription": "If enabled, the completion list will include completions with invalid identifier names. For those entries, The `insertText` and `replacementSpan` properties will be set to change from `.x` property access to `[\"x\"]`."
+                                                },
+                                                "includeAutomaticOptionalChainCompletions": {
+                                                    "type": "boolean",
+                                                    "markdownDescription": "Unless this option is `false`, or `includeCompletionsWithInsertText` is not enabled, member completion lists triggered with `.` will include entries on potentially-null and potentially-undefined values, with insertion text to replace preceding `.` tokens with `?.`."
+                                                },
+                                                "importModuleSpecifierPreference": {
+                                                    "enum": ["shortest", "project-relative", "relative", "non-relative"],
+                                                },
+                                                "importModuleSpecifierEnding": {
+                                                    "enum": ["auto", "minimal", "index", "js"],
+                                                    "markdownDescription": "Determines whether we import `foo/index.ts` as \"foo\", \"foo/index\", or \"foo/index.js\"."
+                                                },
+                                                "allowTextChangesInNewFiles": {
+                                                    "type": "boolean",
+                                                },
+                                                "lazyConfiguredProjectsFromExternalProject": {
+                                                    "type": "boolean",
+                                                },
+                                                "providePrefixAndSuffixTextForRename": {
+                                                    "type": "boolean",
+                                                },
+                                                "provideRefactorNotApplicableReason": {
+                                                    "type": "boolean",
+                                                },
+                                                "allowRenameOfImportPath": {
+                                                    "type": "boolean",
+                                                },
+                                                "includePackageJsonAutoImports": {
+                                                    "enum": ["auto", "on", "off"],
+                                                },
+                                                "displayPartsForJSDoc": {
+                                                    "type": "boolean",
+                                                },
+                                                "generateReturnInDocTemplate": {
+                                                    "type": "boolean",
+                                                },
                                             }
                                         }
                                     }


### PR DESCRIPTION
The schema is based on the latest TS version so it might not apply
when using older TS versions from the project or might get outdated
if we forget to update it for new versions of typescript.

Also, enabled "allowRenameOfImportPath" and "includeCompletionsForImportStatements"
in default settings. Those were not enabled by default by the server.

The "includeCompletionsForModuleExports" and "includeCompletionsWithInsertText"
are enabled by default in the server but added to default settings anyway
for transparency.