### PR TITLE
Explicitly define ST4 selector

### DIFF
--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -53,7 +53,7 @@
 		"typescript.format.trimTrailingWhitespace": true,
 	},
 	// ST4 configuration
-	"selector": "source.js - source.js.flow, source.jsx, source.ts, source.tsx",
+	"selector": "source.js, source.jsx, source.ts, source.tsx",
 	// ST3 configuration
 	"languages": [
 		{

--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -1,36 +1,5 @@
 {
 	"command": ["${node_bin}", "${server_path}", "--stdio"],
-	"languages": [
-		{
-			"languageId": "javascriptreact",
-			"scopes": ["source.jsx", "source.js.react"],
-			"syntaxes": [
-				"Packages/User/JS Custom/Syntaxes/React.sublime-syntax",
-			],
-		},
-		{
-			"languageId": "javascript",
-			"scopes": ["source.js"],
-			"syntaxes": [
-				"Packages/JavaScript/JavaScript.sublime-syntax",
-				"Packages/Babel/JavaScript (Babel).sublime-syntax",
-			],
-		},
-		{
-			"languageId": "typescriptreact",
-			"scopes": ["source.tsx"],
-			"syntaxes": [
-				"Packages/TypeScript Syntax/TypeScriptReact.tmLanguage",
-			],
-		},
-		{
-			"languageId": "typescript",
-			"scopes": ["source.ts"],
-			"syntaxes": [
-				"Packages/TypeScript Syntax/TypeScript.tmLanguage",
-			],
-		},
-	],
 	"initializationOptions": {
 		"logVerbosity": "off",
 		"plugins": [],
@@ -83,4 +52,38 @@
 		"typescript.format.semicolons": "ignore",
 		"typescript.format.trimTrailingWhitespace": true,
 	},
+	// ST4 configuration
+	"selector": "source.js - source.js.flow, source.jsx, source.ts, source.tsx",
+	// ST3 configuration
+	"languages": [
+		{
+			"languageId": "javascriptreact",
+			"scopes": ["source.jsx", "source.js.react"],
+			"syntaxes": [
+				"Packages/User/JS Custom/Syntaxes/React.sublime-syntax",
+			],
+		},
+		{
+			"languageId": "javascript",
+			"scopes": ["source.js"],
+			"syntaxes": [
+				"Packages/JavaScript/JavaScript.sublime-syntax",
+				"Packages/Babel/JavaScript (Babel).sublime-syntax",
+			],
+		},
+		{
+			"languageId": "typescriptreact",
+			"scopes": ["source.tsx"],
+			"syntaxes": [
+				"Packages/TypeScript Syntax/TypeScriptReact.tmLanguage",
+			],
+		},
+		{
+			"languageId": "typescript",
+			"scopes": ["source.ts"],
+			"syntaxes": [
+				"Packages/TypeScript Syntax/TypeScript.tmLanguage",
+			],
+		},
+	],
 }


### PR DESCRIPTION
I think I don't need to include `source.js.react` since it should be matched by `source.js` but haven't verified that.

Fixes #60