### PR TITLE
Implement a custom "find callers" command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 .dependabot export-ignore
 .github/ export-ignore
 codecov.yml export-ignore
+mypy.ini export-ignore
 tests/ export-ignore
 tox.ini export-ignore
 unittesting.json export-ignore

--- a/LSP-typescript.sublime-commands
+++ b/LSP-typescript.sublime-commands
@@ -16,4 +16,11 @@
             "command_args": ["${file}"]
         }
     },
+    {
+        "caption": "LSP-typescript: Find callers",
+        "command": "lsp_typescript_calls",
+        "args": {
+            "direction": "incoming"
+        },
+    },
 ]

--- a/commands.py
+++ b/commands.py
@@ -1,0 +1,48 @@
+from .protocol import Call, CallsDirection, CallsRequestParams, CallsResponse
+from LSP.plugin import Request
+from LSP.plugin import Session
+from LSP.plugin.core.protocol import LocationLink
+from LSP.plugin.core.registry import LspTextCommand
+from LSP.plugin.core.typing import Optional
+from LSP.plugin.core.views import text_document_position_params
+from LSP.plugin.locationpicker import LocationPicker
+import functools
+import sublime
+
+
+SESSION_NAME = "LSP-typescript"
+
+
+class LspTypescriptCallsCommand(LspTextCommand):
+
+    session_name = SESSION_NAME
+
+    def is_enabled(self) -> bool:
+        selection = self.view.sel()
+        return len(selection) > 0 and super().is_enabled()
+
+    def run(self, edit: sublime.Edit, direction: CallsDirection) -> None:
+        session = self.session_by_name(self.session_name)
+        if session is None:
+            return
+        position_params = text_document_position_params(self.view, self.view.sel()[0].b)
+        params = {
+            'textDocument': position_params['textDocument'],
+            'position': position_params['position'],
+            'direction': direction
+        }  # type: CallsRequestParams
+        session.send_request(Request("textDocument/calls", params), functools.partial(self.on_result_async, session))
+
+    def on_result_async(self, session: Session, result: Optional[CallsResponse]) -> None:
+        if not result:
+            return
+
+        def to_location_link(call: Call) -> LocationLink:
+            return {
+                'targetUri': call['location']['uri'],
+                'targetSelectionRange': call['location']['range'],
+            }
+
+        locations = list(map(to_location_link, result['calls']))
+        self.view.run_command("add_jump_record", {"selection": [(r.a, r.b) for r in self.view.sel()]})
+        LocationPicker(self.view, session, locations, side_by_side=False)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+# ignore_missing_imports = True
+# check_untyped_defs = True
+disallow_untyped_defs = True
+strict_optional = True

--- a/plugin.py
+++ b/plugin.py
@@ -43,12 +43,12 @@ class LspTypescriptPlugin(NpmClientHandler):
             return 'This server only works when the window workspace includes some folders!'
 
     @request_handler('_typescript.rename')
-    def on_typescript_rename(self, textDocumentPositionParams: Any, respond: Callable[[None], None]) -> None:
-        filename = uri_to_filename(textDocumentPositionParams['textDocument']['uri'])
+    def on_typescript_rename(self, position_params: Any, respond: Callable[[None], None]) -> None:
+        filename = uri_to_filename(position_params['textDocument']['uri'])
         view = sublime.active_window().open_file(filename)
 
         if view:
-            lsp_point = Point.from_lsp(textDocumentPositionParams['position'])
+            lsp_point = Point.from_lsp(position_params['position'])
             point = point_to_offset(lsp_point, view)
 
             sel = view.sel()

--- a/protocol.py
+++ b/protocol.py
@@ -1,0 +1,29 @@
+from LSP.plugin.core.protocol import Location, Position, RangeLsp, TextDocumentIdentifier
+from LSP.plugin.core.typing import List, Literal, Optional, TypedDict, Union
+
+
+CallsDirection = Union[Literal['incoming'], Literal['outgoing']]
+
+CallsRequestParams = TypedDict('CallsRequestParams', {
+    'textDocument': TextDocumentIdentifier,
+    'position': Position,
+    'direction': CallsDirection
+}, total=True)
+
+DefinitionSymbol = TypedDict('DefinitionSymbol', {
+    'name': str,
+    'detail': Optional[str],
+    'kind': int,
+    'location': Location,
+    'selectionRange': RangeLsp,
+}, total=True)
+
+Call = TypedDict('Call', {
+    'location': Location,
+    'symbol': DefinitionSymbol,
+}, total=True)
+
+CallsResponse = TypedDict('CallsResponse', {
+    'symbol': Optional[DefinitionSymbol],
+    'calls': List[Call],
+}, total=True)


### PR DESCRIPTION
typescript-language-server implements a custom "textDocument/calls"
request which is a lot like normal "find references" but it skips all
references that are not calling the symbol. So it filters a lot of
noise like references to function being imported or just passed around.

The "textDocument/calls" request supports finding both callers
(implemented here) and an sort of opposite mode of operation where it
finds all functions called inside the selected symbol (function). I find
that kinda useless so didn't implement it but it can be easily added
by creating another `lsp_typescript_calls` command and passing
"direction": "outgoing" argument to it.