### PR TITLE
Add comments to string-valued settings that show the valid values

### DIFF
--- a/LSP-typescript.sublime-settings
+++ b/LSP-typescript.sublime-settings
@@ -30,13 +30,13 @@
 		"javascript.format.insertSpaceBeforeTypeAnnotation": false,
 		"javascript.format.placeOpenBraceOnNewLineForControlBlocks": false,
 		"javascript.format.placeOpenBraceOnNewLineForFunctions": false,
-		"javascript.format.semicolons": "ignore",
+		"javascript.format.semicolons": "ignore", // ignore | insert | remove
 		"javascript.format.trimTrailingWhitespace": true,
 		// Javascript inlay hints options.
 		"javascript.inlayHints.includeInlayEnumMemberValueHints": false,
 		"javascript.inlayHints.includeInlayFunctionLikeReturnTypeHints": false,
 		"javascript.inlayHints.includeInlayFunctionParameterTypeHints": false,
-		"javascript.inlayHints.includeInlayParameterNameHints": "none",
+		"javascript.inlayHints.includeInlayParameterNameHints": "none", // none | literals | all
 		"javascript.inlayHints.includeInlayParameterNameHintsWhenArgumentMatchesName": false,
 		"javascript.inlayHints.includeInlayPropertyDeclarationTypeHints": false,
 		"javascript.inlayHints.includeInlayVariableTypeHints": false,
@@ -58,13 +58,13 @@
 		"typescript.format.insertSpaceBeforeTypeAnnotation": false,
 		"typescript.format.placeOpenBraceOnNewLineForControlBlocks": false,
 		"typescript.format.placeOpenBraceOnNewLineForFunctions": false,
-		"typescript.format.semicolons": "ignore",
+		"typescript.format.semicolons": "ignore", // ignore | insert | remove
 		"typescript.format.trimTrailingWhitespace": true,
 		// Typescript inlay hints options.
 		"typescript.inlayHints.includeInlayEnumMemberValueHints": false,
 		"typescript.inlayHints.includeInlayFunctionLikeReturnTypeHints": false,
 		"typescript.inlayHints.includeInlayFunctionParameterTypeHints": false,
-		"typescript.inlayHints.includeInlayParameterNameHints": "none",
+		"typescript.inlayHints.includeInlayParameterNameHints": "none", // none | literals | all
 		"typescript.inlayHints.includeInlayParameterNameHintsWhenArgumentMatchesName": false,
 		"typescript.inlayHints.includeInlayPropertyDeclarationTypeHints": false,
 		"typescript.inlayHints.includeInlayVariableTypeHints": false,


### PR DESCRIPTION
Not sure if anyone else finds this kind of thing useful, but having a quick reference for the settings that take a string is nice.